### PR TITLE
Removing security-bundle per symfony 2.8 req

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "3.*",
         "symfony/form": "3.*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "3.*",
-        "symfony/form": "3.*",
-        "symfony/security-bundle": "3.*"
+        "symfony/form": "3.*"
     },
     "require-dev": {
         "twig/twig": "~1.5",

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.2",
-        "symfony/form": "3.*"
+        "php": ">=5.3.2"
     },
     "require-dev": {
         "twig/twig": "~1.5",


### PR DESCRIPTION
Removing security-bundle per symfony 2.8 requirements. symfony/symfony replaces symfony/security-bundle on 2.8.*